### PR TITLE
Add sources to npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,7 +3,6 @@
 coverage/
 lib/*.map
 lib/*.spec.*
-src/
 .nycrc
 jasmine.json
 tsconfig.json


### PR DESCRIPTION
It seems Microsoft is not merging in PRs into Azure/fetch-event-source, some of which are from 2022. Your fork is great for node, but I have been running into a sourcemap issue with webpack, which another PR on the main package solves. Would be great if we could just add this to your package as well, since it seems like we might have to use it for the time being if nothing else.