### PR TITLE
feat(headers): allow headers to be defined as a function, to return dynamic values

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -5,11 +5,15 @@ export const EventStreamContentType = 'text/event-stream';
 const DefaultRetryInterval = 1000;
 const LastEventId = 'last-event-id';
 
-export interface FetchEventSourceInit extends RequestInit {
+export interface FetchEventSourceInit extends Omit<RequestInit, 'headers'> {
     /**
-     * The request headers. FetchEventSource only supports the Record<string,string> format.
+     * The request headers. FetchEventSource only supports the Record<string,string> format,
+     * or a function that returns the Record<string,string> format.
+     *
+     * Passing headers as a function allows you to set dynamic headers, useful in scenarios
+     * such as updating the Authorization header with a new bearer token.
      */
-    headers?: Record<string, string>,
+    headers?: Record<string, string> | (() => Record<string, string>),
 
     /**
      * Called when a response is received. Use this to validate that the response
@@ -64,13 +68,15 @@ export function fetchEventSource(input: RequestInfo, {
     fetch: inputFetch,
     ...rest
 }: FetchEventSourceInit) {
-    return new Promise<void>((resolve, reject) => {
+    let getHeaders: () => Record<string, string>;
+    if (typeof inputHeaders === 'function') {
+        getHeaders = inputHeaders;
+    } else {
         // make a copy of the input headers since we may modify it below:
-        const headers = { ...inputHeaders };
-        if (!headers.accept) {
-            headers.accept = EventStreamContentType;
-        }
+        getHeaders = () => ({ ...inputHeaders });
+    }
 
+    return new Promise<void>((resolve, reject) => {
         let curRequestController: AbortController;
         function onVisibilityChange() {
             curRequestController.abort(); // close existing request on every visibility change
@@ -102,6 +108,11 @@ export function fetchEventSource(input: RequestInfo, {
         const fetchFn = inputFetch ?? fetch;
         const onopen = inputOnOpen ?? defaultOnOpen;
         async function create() {
+            const headers = getHeaders();
+            if (!headers.accept) {
+                headers.accept = EventStreamContentType;
+            }
+
             curRequestController = new AbortController();
             try {
                 const response = await fetchFn(input, {


### PR DESCRIPTION
I am using this library as a means to provide a JWT bearer token via the `Authorization` header to my event source endpoint.

However I have found that when the connection is retried (either [explicitly](https://github.com/gfortaine/fetch-event-source/blob/main/src/fetch.ts#L138), or via the [page visibility API](https://github.com/gfortaine/fetch-event-source/blob/main/src/fetch.ts#L78)), it reuses the headers that were first passed to `fetchEventSource`.

In my use case, as bearer tokens are short lived, the retry uses a _stale_ bearer token and the retry call fails as unauthorised.

This PR adds the ability to pass `headers` as a _function_, meaning you can pass dynamic values, such as an up-to-date bearer token. It is also backwards compatible with the existing behaviour.

#### Example (using React)

```ts
const getAccessToken = useAccessToken();

useEffect(() => {
  fetchEventSource(endpoint, {
    headers: () => ({
      Authorization: `Bearer ${getAccessToken()}`,
      Accept: 'application/json',
    }),
    // etc
  })
}, [getAccessToken]);
```